### PR TITLE
Fix wrong white background color and applied opacity in mobile nav menu toggle button

### DIFF
--- a/styles/nav.css
+++ b/styles/nav.css
@@ -49,7 +49,6 @@ span.nav-toggle {
     font-size: var(--font-size-nav-toggle);
     display: flex;
     height: auto;
-    background-color: var(--warm);
     border: 0;
     border-radius: 0;
     width: auto;
@@ -57,7 +56,6 @@ span.nav-toggle {
   }
 
   span.nav-toggle:hover {
-    background-color: var(--white);
     -webkit-box-shadow: 0 0 0 0;
     box-shadow: 0 0 0 0;
     color: var(--dark-gray);
@@ -128,25 +126,17 @@ span.nav-toggle {
   margin: 0;
   overflow: visible;
 }
-.hamburger:hover {
-  opacity: 0.7;
-}
-.hamburger.is-active:hover {
-  opacity: 0.7;
-}
 .hamburger.is-active .hamburger-inner,
 .hamburger.is-active .hamburger-inner::before,
 .hamburger.is-active .hamburger-inner::after {
   background-color: #000;
 }
-
 .hamburger-box {
   width: 24px;
   height: 24px;
   display: inline-block;
   position: relative;
 }
-
 .hamburger-inner {
   display: block;
   top: 50%;
@@ -189,7 +179,6 @@ span.nav-toggle {
     bottom 0.075s 0.12s ease,
     transform 0.075s cubic-bezier(0.55, 0.055, 0.675, 0.19);
 }
-
 .hamburger--squeeze.is-active .hamburger-inner {
   transform: rotate(45deg);
   transition-delay: 0.12s;


### PR DESCRIPTION
- Remove the `--white` background color of the "X" icon after pressing the hamburger icon
- Remove the opacity reduction because on mobile the hover and active states aren't unapplied, resulting in a weird gray color even after have tapped the hamburger icon

| Before | After |
| ------ | ----- |
| <img width="441" alt="image" src="https://github.com/user-attachments/assets/7cbbb977-a988-457c-bfc0-cfccb5cbb022"> | <img width="442" alt="image" src="https://github.com/user-attachments/assets/6205b85b-66e6-43fe-8e66-68c93a6eb5d4"> |